### PR TITLE
Fixed typo in GetSparseExtent

### DIFF
--- a/parser/context.go
+++ b/parser/context.go
@@ -188,7 +188,7 @@ func GetVMDKContext(
 
 				switch extent_type {
 				case "SPARSE":
-					extent, err := GetSpaseExtent(reader)
+					extent, err := GetSparseExtent(reader)
 					if err != nil {
 						return nil, fmt.Errorf("While opening %v: %w",
 							extent_filename, err)

--- a/parser/sparse.go
+++ b/parser/sparse.go
@@ -81,7 +81,7 @@ func (self *SparseExtent) getGrainForOffset(offset int64) (
 	return grain_start + offset_within_grain, self.grain_size - offset_within_grain, nil
 }
 
-func GetSpaseExtent(reader io.ReaderAt) (*SparseExtent, error) {
+func GetSparseExtent(reader io.ReaderAt) (*SparseExtent, error) {
 	profile := NewVMDKProfile()
 	res := &SparseExtent{
 		profile: profile,


### PR DESCRIPTION
This pull request includes corrections to function names in the `parser` package to fix typos and ensure consistency.

Function name corrections:

* [`parser/context.go`](diffhunk://#diff-b083a93328928c4f7c936ff8699ebc99f6aeca7389180ba7f7e7d34cf02d59f0L191-R191): Corrected the function name from `GetSpaseExtent` to `GetSparseExtent` in the `GetVMDKContext` function.
* [`parser/sparse.go`](diffhunk://#diff-c6156f30c74ea03af28c7f8097bccef8befb76522f826f60edcabaa3c1f4bab4L84-R84): Corrected the function name from `GetSpaseExtent` to `GetSparseExtent` in the function definition.